### PR TITLE
Added support for blocking cookies

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -35,6 +35,9 @@
   "changeMatchingToURL": {
     "message": "This action will clear your blacklist entirely; are you sure you want your blacklist to be matched on URLs?"
   },
+  "enableBlacklistCookies": {
+    "message": "This action will enable the removal of cookies belonging to blacklist entries upon session end (read: tab closed, window closed, and 'Block' actions). Many sites rely on cookies for detecting whether users are logged in, among many other features."
+  },
   "importBlacklist": {
     "message": "Enter a comma-separated list of hashes to import."
   }

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,9 @@
     "tabs",
     "history",
     "storage",
-    "contextMenus"
+    "contextMenus",
+    "cookies",
+    "<all_urls>"
   ],
 
   "background": {

--- a/options/index.html
+++ b/options/index.html
@@ -30,6 +30,11 @@
       <label title="Match the entire URL; example: https://foo.bar.com/baz -> foo.bar.com/baz" for="url">Full URL</label>
     </inputs>
   </row>
+  <row>
+    <name>User Data</name>
+    <input type="checkbox" name="cookies" id="cookies"></input>
+    <label title="Delete cookies which are blacklisted" for="id">Cookies</label>
+  </row>
   <row class="nounderline">
     <name>Blacklist</name>
   </row>

--- a/options/options.js
+++ b/options/options.js
@@ -7,6 +7,7 @@ class Options {
 
     this.renderBlacklistType();
     this.renderBlacklistMatching();
+    this.renderBlacklistCookies();
     this.renderBlacklist();
   }
 
@@ -15,17 +16,26 @@ class Options {
    */
   attachDOMListeners() {
     document.querySelector("#resetBlacklist").addEventListener(
-      "click", () => this.resetBlacklist());
+      "click", () => this.resetBlacklist()
+    );
     document.querySelector("#addToBlacklist").addEventListener(
-      "click", () => this.addToBlacklist());
+      "click", () => this.addToBlacklist()
+    );
     document.querySelector("#removeFromBlacklist").addEventListener(
-      "click", () => this.removeFromBlacklist());
+      "click", () => this.removeFromBlacklist()
+    );
     document.querySelector("#blacklisttype").addEventListener(
-      "change", event => this.changeBlacklistType(event.target.value));
+      "change", event => this.changeBlacklistType(event.target.value)
+    );
     document.querySelector("#blacklistmatching").addEventListener(
-      "change", event => this.changeBlacklistMatching(event.target.value));
+      "change", event => this.changeBlacklistMatching(event.target.value)
+    );
+    document.querySelector("#cookies").addEventListener(
+      "change", event => this.changeCookies(event.target.checked)
+    );
     document.querySelector("#import").addEventListener(
-      "click", () => this.importBlacklist() );
+      "click", () => this.importBlacklist()
+    );
   }
 
   /**
@@ -34,7 +44,7 @@ class Options {
    *
    * @param {string} message
    *        The message.
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled when the message has been 
    *         handled.
    */
@@ -48,7 +58,7 @@ class Options {
   /**
    * Sends a message to have HistoryBlock clear the blacklist.
    * 
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the blacklist has been 
    *         cleared.
    */
@@ -62,7 +72,7 @@ class Options {
   /**
    * Sends a message to have HistoryBlock add the given URLs to the blacklist.
    *
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the input has been added to
    *         the blacklist.
    */
@@ -82,7 +92,7 @@ class Options {
   /**
    * Sends a message to have HistoryBlock import the given blacklist.
    * 
-   * @return {Promise} blacklist
+   * @return {Promise}
    *         A Promise that will be fulfilled after the input has been added to
    *         the blacklist.
    */
@@ -97,7 +107,7 @@ class Options {
   /**
    * Sends a message to have HistoryBlock remove the given URLs from the blacklist.
    *
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the input has been removed
    *         from the blacklist.
    */
@@ -119,7 +129,7 @@ class Options {
    *
    * @param {string} blacklistType
    *        The type of encryption to use on blacklist entries.
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the blacklist encryption 
    *         type has been changed.
    */
@@ -139,7 +149,7 @@ class Options {
    *
    * @param {string} matching
    *        The technique of matching to use on URLs.
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the blacklist URL matching
    *         technique has been changed.
    */
@@ -157,9 +167,24 @@ class Options {
   }
 
   /**
+   * Sends a message to have HistoryBlock change whether cookies are blacklisted.
+   * 
+   * @param {string} blacklistCookies 
+   *        Whether or not cookies should be blacklisted
+   */
+  async changeCookies(blacklistCookies) {
+    if((blacklistCookies && confirm(browser.i18n.getMessage('enableBlacklistCookies'))) ||
+       !blacklistCookies) {
+      await browser.runtime.sendMessage({action: 'changeBlacklistCookies', blacklistCookies:blacklistCookies});
+    }
+
+    await this.renderBlacklistCookies();
+  }
+
+  /**
    * Renders the blacklist encryption type controls.
    *
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the blacklist encryption
    *         type elements have been rendered.
    */
@@ -190,7 +215,7 @@ class Options {
   /**
    * Renders the blacklist matching technique controls.
    *
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the blacklist URL matching
    *         technique elements have been rendered.
    */
@@ -212,9 +237,26 @@ class Options {
   }
 
   /**
+   * Renders the blacklist cookies option controls.
+   * 
+   * @return {Promise}
+   *         A Promise that will be fulfilled after the blacklist cookies
+   *         control elements have been rendered.
+   */
+  async renderBlacklistCookies() {
+    let storage = await browser.storage.sync.get();
+
+    if(typeof storage.blacklistCookies !== 'boolean') {
+      storage.blacklistCookies = false;
+    }
+
+    document.querySelector("#cookies").checked = storage.blacklistCookies;
+  }
+
+  /**
    * Renders the blacklist.
    *
-   * @return {Promise} promise
+   * @return {Promise}
    *         A Promise that will be fulfilled after the blacklist has been 
    *         rendered.
    */


### PR DESCRIPTION
Adds a setting which determines whether HistoryBlock should remove cookies belonging to the blacklisted site on actionable events (blacklisted tab closed, window with blacklisted tab at index-0 closed, and context-menu 'Block' action).