### PR TITLE
Add example to Full URL matcher class docstring

### DIFF
--- a/libraries/URLMatcher.js
+++ b/libraries/URLMatcher.js
@@ -2,6 +2,8 @@ class URLMatcher extends Matcher {
 
   /**
    * Returns the given URL without query parameters and anchors.
+   * Examples:
+   *   https://www.google.com/search?q=foo#bar -> www.google.com/search
    *
    * @param {string} url
    *        The url to return.


### PR DESCRIPTION
Add an example to the docstring of the URLMatcher class,
similar to the ones in the DomainMatcher and SubdomainMatcher classes.
